### PR TITLE
Updated Facebook-iOS-SDK to 3.17.0

### DIFF
--- a/EasyFacebook.podspec
+++ b/EasyFacebook.podspec
@@ -10,6 +10,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.ios.deployment_target = '7.0'
 
-  s.dependency 'Facebook-iOS-SDK', '~>3.16.2'
+  s.dependency 'Facebook-iOS-SDK', '~>3.17.0'
   s.dependency 'FXKeychain', '~>1.5.1'
 end


### PR DESCRIPTION
This enables using Parse.com SDK as his Framework uses 3.17.0
